### PR TITLE
Fixes #34827 - use mqtts to connect to the broker

### DIFF
--- a/katello-pull-transport-migrate
+++ b/katello-pull-transport-migrate
@@ -44,7 +44,7 @@ if [ -f $CONFIGTOML ]; then
     cat <<EOF > $CONFIGTOML
 # yggdrasil global configuration settings written by katello-pull-transport-migrate
 
-broker = ["tcp://$SERVER_NAME:1883"]
+broker = ["mqtts://$SERVER_NAME:1883"]
 cert-file = "$CERT_FILE"
 key-file = "$KEY_FILE"
 ca-root = ["$CA_FILE"]


### PR DESCRIPTION
`tcp://` is unencrypted and thus omits client certs