### PR TITLE
Fixes #35611 - Make yggdrasil config compatible with newer versions

### DIFF
--- a/katello-pull-transport-migrate
+++ b/katello-pull-transport-migrate
@@ -45,6 +45,7 @@ if [ -f $CONFIGTOML ]; then
 # yggdrasil global configuration settings written by katello-pull-transport-migrate
 
 broker = ["mqtts://$SERVER_NAME:1883"]
+server = "mqtts://$SERVER_NAME:1883"
 cert-file = "$CERT_FILE"
 key-file = "$KEY_FILE"
 ca-root = ["$CA_FILE"]


### PR DESCRIPTION
The broker option got renamed to server and is a string instead of an array. Luckily we can provide both to make it work with both old and new versions

https://github.com/RedHatInsights/yggdrasil/discussions/53